### PR TITLE
fixes, cleanups, and new options

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Jérôme Quelin <jquelin@gmail.com>

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 {{$NEXT}}
+  - Removed old and broken links from Pod
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
   - add filename option to customize the generated file name
   - critic_config option will no longer be ignored if the file doesn't exist
   - add verbose option to set Perl::Critic's verbose option
+  - add profile as an alias for the critic_config option
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
   - Removed old and broken links from Pod
   - Test::Perl::Critic is no longer a direct dependency. It is used in the
     generated test, but not by the module itself.
+  - add filename option to customize the generated file name
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
     generated test, but not by the module itself.
   - add filename option to customize the generated file name
   - critic_config option will no longer be ignored if the file doesn't exist
+  - add verbose option to set Perl::Critic's verbose option
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 {{$NEXT}}
   - Removed old and broken links from Pod
+  - Test::Perl::Critic is no longer a direct dependency. It is used in the
+    generated test, but not by the module itself.
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
   - Test::Perl::Critic is no longer a direct dependency. It is used in the
     generated test, but not by the module itself.
   - add filename option to customize the generated file name
+  - critic_config option will no longer be ignored if the file doesn't exist
 
 3.001     2017-05-09 22:32:01Z
  - Test::Perl::Critic is now injected into the distribution as a develop prereq

--- a/dist.ini
+++ b/dist.ini
@@ -7,7 +7,6 @@ copyright_year   = 2009
 ; -- static meta-information
 [MetaResources]
 x_IRC = irc://irc.perl.org/#distzilla
-x_MailingList = http://dzil.org/#mailing-list
 
 [Bootstrap::lib]
 

--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,3 @@ copy_file_from_release = AUTHOR_PLEDGE
 ; Test ourself
 ; (this is not in @Author::JQUELIN or @Author::ETHER)
 [Test::Perl::Critic]
-
-[Prereqs]
-Test::Perl::Critic = 0

--- a/lib/Dist/Zilla/Plugin/CriticTests.pm
+++ b/lib/Dist/Zilla/Plugin/CriticTests.pm
@@ -11,6 +11,8 @@ before register_component => sub {
   warn "!!! [CriticTests] is deprecated and may be removed in the future; replace it with [Test::Perl::Critic]\n";
 };
 
+=for stopwords LICENCE
+
 =head1 SYNOPSIS
 
 THIS MODULE IS DEPRECATED, PLEASE USE

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -47,6 +47,10 @@ has critic_config => (
     isa     => 'Str',
 );
 
+has verbose => (
+    is => 'ro',
+);
+
 sub gather_files {
     my $self = shift;
     $self->add_file( $self->_file );
@@ -86,6 +90,9 @@ sub munge_file {
         unless $file == $self->_file;
 
     my $options = {};
+    if (defined(my $verbose = $self->verbose)) {
+        $options->{'-verbose'} = $verbose;
+    }
     if (my $profile = $self->critic_config) {
         $options->{'-profile'} = $profile;
     }
@@ -146,6 +153,10 @@ This plugin accepts the C<critic_config> option, which s
 Specifies your own config file for L<Perl::Critic>. It defaults to
 C<perlcritic.rc>, relative to the project root. If the file does not exist,
 L<Perl::Critic> will use its defaults.
+
+=head2 verbose
+
+If configured, overrides the C<-verbose> option to L<Perl::Critic>.
 
 =head1 SEE ALSO
 

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -67,6 +67,8 @@ __PACKAGE__->meta->make_immutable;
 
 =for Pod::Coverage gather_files register_prereqs
 
+=for stopwords LICENCE
+
 =head1 SYNOPSIS
 
 In your F<dist.ini>:

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -42,6 +42,10 @@ has _file => (
     },
 );
 
+sub mvp_aliases { {
+    profile => 'critic_config',
+} }
+
 has critic_config => (
     is      => 'ro',
     isa     => 'Str',
@@ -118,7 +122,7 @@ __PACKAGE__->meta->make_immutable;
 1;
 =pod
 
-=for Pod::Coverage gather_files register_prereqs munge_file
+=for Pod::Coverage gather_files register_prereqs munge_file mvp_aliases
 
 =for stopwords LICENCE
 
@@ -153,6 +157,8 @@ This plugin accepts the C<critic_config> option, which s
 Specifies your own config file for L<Perl::Critic>. It defaults to
 C<perlcritic.rc>, relative to the project root. If the file does not exist,
 L<Perl::Critic> will use its defaults.
+
+The option can also be configured using the C<profile> alias.
 
 =head2 verbose
 

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -100,29 +100,9 @@ You can look for information on this module at:
 
 =over 4
 
-=item * Search CPAN
-
-L<http://search.cpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic>
-
 =item * See open / report bugs
 
 L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dist-Zilla-Plugin-Test-Perl-Critic>
-
-=item * Mailing-list (same as L<Dist::Zilla>)
-
-L<http://www.listbox.com/subscribe/?list_id=139292>
-
-=item * Git repository
-
-L<http://github.com/jquelin/dist-zilla-plugin-test-perl-critic>
-
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/Dist-Zilla-Plugin-Test-Perl-Critic>
-
-=item * CPAN Ratings
-
-L<http://cpanratings.perl.org/d/Dist-Zilla-Plugin-Test-Perl-Critic>
 
 =back
 

--- a/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
+++ b/lib/Dist/Zilla/Plugin/Test/Perl/Critic.pm
@@ -20,6 +20,11 @@ with qw(
     Dist::Zilla::Role::PrereqSource
 );
 
+has filename => (
+    is => 'ro',
+    default => 'xt/author/critic.t',
+);
+
 has critic_config => (
     is      => 'ro',
     isa     => 'Maybe[Str]',
@@ -35,15 +40,12 @@ sub gather_files {
     my $stash = get_all_attribute_values( $self->meta, $self);
     $stash->{critic_config} ||= 'perlcritic.rc';
 
-    # NB: This code is a bit generalised really, and could be forked into its
-    # own plugin.
-    for my $name ( keys %$data ){
-        my $template = ${$data->{$name}};
-        $self->add_file( Dist::Zilla::File::InMemory->new({
-            name => $name,
-            content => $self->fill_in_string( $template, $stash )
-        }));
-    }
+    my $name = $self->filename;
+    my $template = ${$data->{'test-perl-critic'}};
+    $self->add_file( Dist::Zilla::File::InMemory->new({
+        name => $name,
+        content => $self->fill_in_string( $template, $stash )
+    }));
 }
 
 sub register_prereqs {
@@ -88,11 +90,18 @@ above and run one of the following:
 During these runs, F<xt/author/critic.t> will use L<Test::Perl::Critic> to run
 L<Perl::Critic> against your code and by report findings.
 
-This plugin accepts the C<critic_config> option, which specifies your own config
-file for L<Perl::Critic>. It defaults to C<perlcritic.rc>, relative to the
-project root. If the file does not exist, L<Perl::Critic> will use its defaults.
+=head1 OPTIONS
 
-This plugin is an extension of L<Dist::Zilla::Plugin::InlineFiles>.
+=head2 filename
+
+The file name of the test to generate. Defaults to F<xt/author/critic.t>.
+
+=head2 critic_config
+
+This plugin accepts the C<critic_config> option, which s
+Specifies your own config file for L<Perl::Critic>. It defaults to
+C<perlcritic.rc>, relative to the project root. If the file does not exist,
+L<Perl::Critic> will use its defaults.
 
 =head1 SEE ALSO
 
@@ -111,7 +120,7 @@ L<http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dist-Zilla-Plugin-Test-Perl-Critic>
 =cut
 
 __DATA__
-___[ xt/author/critic.t ]___
+___[ test-perl-critic ]___
 #!perl
 
 use strict;


### PR DESCRIPTION
A number of these changes rely on others, so it would be rather inconvenient to file as separate PRs.

  - Cleans up pod and packaging a bit
  - remove direct dependency on Test::Perl::Critic, it is needed by the test, not directly by the plugin
  - add filename option to customize the output file
  - fix critic_config option to not be ignored when the file doesn't exist
  - add verbose option
  - add profile as an alias for critic_config