### PR TITLE
add files and finder options to limit files

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 {{$NEXT}}
+  - added files and filter options to specify files to criticise
 
 3.003     2024-10-14 17:34:00Z
   - fix ignored options (RT#156116)

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -127,6 +127,67 @@ subtest 'undef' => sub {
     like($critic_test, qr{$critic_config}, 'Right config file used')
 };
 
+subtest 'files' => sub {
+    plan tests => 3;
+
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', ['Test::Perl::Critic', { files => 'lib/My/Module.pm' }])
+                ),
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        @{ $tzil->files }
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain @{ $tzil->files };
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{all_critic_ok\(\s*"lib/My/Module\.pm"},
+      'Includes file');
+};
+
+subtest 'finder' => sub {
+    plan tests => 4;
+
+    my $tzil = Builder->from_config(
+        { dist_root => 'corpus/dist/DZT' },
+        {
+            add_files => {
+                'source/dist.ini' => simple_ini(
+                    ('GatherDir', ['Test::Perl::Critic', { finder => ':InstallModules' }])
+                ),
+                'source/lib/My/Module.pm' => "package My::Module; 1;",
+                'source/inc/My/Include.pm' => "package My::Include; 1;",
+            },
+        },
+    );
+
+    $tzil->build;
+
+    my $has_test = grep(
+        $_->name eq $test_name,
+        @{ $tzil->files }
+    );
+    ok($has_test, 'Perl::Critic test exists')
+        or diag explain @{ $tzil->files };
+
+    my $critic_test = $tzil->slurp_file("build/$test_name");
+    like($critic_test, qr{Test::Perl::Critic}, 'We have a Perl::Critic test');
+    like($critic_test, qr{all_critic_ok\(\s*"lib/My/Module\.pm"},
+      'Includes installed modules');
+    unlike($critic_test, qr{inc/My/Include\.pm}, "Doesn't include inc modules");
+};
+
 done_testing;
 
 END { # Remove (empty) dir created by building the dists


### PR DESCRIPTION
The default behavior of Test::Perl::Critic is to check all files it can find. Sometimes that isn't desired.

Add a files option to specify files manually, as well as a finder option to specify a file finder.

The default behavior is still to use Test::Perl::Critic's defaults.