### PR TITLE
disable ProhibitExplicitReturnUndef critic policy

### DIFF
--- a/perlcritic.rc
+++ b/perlcritic.rc
@@ -1,0 +1,1 @@
+[-Subroutines::ProhibitExplicitReturnUndef]


### PR DESCRIPTION
The policy is just wrong. return undef is what you should do for subs that return single items.