### PR TITLE
Add option embed_critic_config

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 3.004     2024-10-20 22:37:37Z
   - added files and filter options to specify files to criticise
+  - added option embed_critic_config (Mikko Koivunalho)
 
 3.003     2024-10-14 17:34:00Z
   - fix ignored options (RT#156116)

--- a/Changes
+++ b/Changes
@@ -1,10 +1,10 @@
 Revision history for Dist::Zilla::Plugin::Test::Perl::Critic
 
 {{$NEXT}}
+  - added option embed_critic_config (Mikko Koivunalho)
 
 3.004     2024-10-20 22:37:37Z
   - added files and filter options to specify files to criticise
-  - added option embed_critic_config (Mikko Koivunalho)
 
 3.003     2024-10-14 17:34:00Z
   - fix ignored options (RT#156116)

--- a/README.pod
+++ b/README.pod
@@ -48,6 +48,23 @@ L<Perl::Critic> will use its defaults.
 
 The option can also be configured using the C<profile> alias.
 
+=head2 embed_critic_config
+
+This option causes the plugin to read the profile file specified
+by option C<critic_config> or L<Perl::Critic> default config
+file F<.perlcriticrc> and embed the file into the test
+file F<xt/author/critic.t>.
+
+This option makes it possible to exclude the Perl::Critic config
+file from the distribution because all the configuration is embedded
+into the test file. It also means you can use the standard default
+config file name F<.perlcriticrc> which was difficult before
+because dot files are, by default, left out of the distribution package.
+
+By using the default config file F<.perlcriticrc>, you can run
+C<perlcritic> on the command line and use the same configuration
+without additional command line arguments.
+
 =head2 verbose
 
 If configured, overrides the C<-verbose> option to L<Perl::Critic>.


### PR DESCRIPTION
I am a heavy user of Dist::Zilla and Perl::Critic.
I have created this PR to fix two issues which have been bugging me:
1) The Perl::Critic config file has to be included in the distro. In my mind, it has no reason to be included. It is a development aid, not for users.
2) The default name of the config file is different from what Perl::Critic itself expects. This makes it difficult to run the same tests by `perlcritic` alone.

Perhaps this change is too incompatible?
I have also considered if there should rather be another Dist::Zilla plugin to do this.
I am open to both alternatives. I am, of course, also open to change anything in the PR.

************

This option causes the plugin to read the profile file specified
by option **critic_config** or Perl::Critic default config
file **.perlcriticrc** and embed the file into the test
file **xt/author/critic.t**.

This option makes it possible to exclude the Perl::Critic config
file from the distribution because all the configuration is embedded
into the test file. It also means you can use the standard default
config file name **perlcriticrc** which was difficult before                                                                                                  
because dot files are, by default, left out of the distribution package.

By using the default config file **.perlcriticrc**, you can run
**perlcritic** on the command line and use the same configuration
without additional command line arguments.